### PR TITLE
change hash matching algorithm

### DIFF
--- a/passhash.js
+++ b/passhash.js
@@ -23,14 +23,7 @@ module.exports = function(length, callback, cmd){
 			output += data;
 		});
 		torProcess.on('close', function(){
-			output = output.split('\n');
-			var hash;
-			for (var i = output.length - 1; i > 0; i--){
-				if (output[i] && output[i] != ""){
-					hash = output[i];
-					break;
-				}
-			}
+			var hash = output.match(/(^16:[0-9A-F]{58})/)[0];
 			callback(pass, hash);
 		});
 	}


### PR DESCRIPTION
The current hash matching algorithm fails with latest tor build from github (2.7.0-alpha). This new one works.

Edit: works with tor v0.2.5.10 as well.

You can see here that the '16:' is in fact hard coded into the hash: https://github.com/torproject/tor/blob/master/src/or/main.c#L2813
