### PR TITLE
add m multiline switch to regex for tor 2.5.x

### DIFF
--- a/passhash.js
+++ b/passhash.js
@@ -23,7 +23,7 @@ module.exports = function(length, callback, cmd){
 			output += data;
 		});
 		torProcess.on('close', function(){
-			var hash = output.match(/(^16:[0-9A-F]{58})/)[0];
+			var hash = output.match(/(^16:[0-9A-F]{58})/m)[0];
 			callback(pass, hash);
 		});
 	}


### PR DESCRIPTION
I had a chance to actually test this with tor 2.5.x and because of additional spew generated by tor, the 'm' multi-line switch is required on the regex.
